### PR TITLE
Add MAGICK_CONFIGURE_PATH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -93,5 +93,6 @@ mkdir -p $(dirname $PROFILE_PATH)
 
 echo "export CPATH=$CPATH:$ACTUAL_INSTALL_PATH/include:$INSTALL_DIR/include" >> $PROFILE_PATH
 echo "export PATH=$ACTUAL_INSTALL_PATH/bin:\$PATH" >> $PROFILE_PATH
-echo "export PATH=$ACTUAL_INSTALL_PATH/etc/ImageMagick-6:\$PATH" >> $PROFILE_PATH
+echo "export PATH=$ACTUAL_INSTALL_PATH/etc/ImageMagick-7:\$PATH" >> $PROFILE_PATH
 echo "export LD_LIBRARY_PATH=$ACTUAL_INSTALL_PATH/lib:\$LD_LIBRARY_PATH" >> $PROFILE_PATH
+echo "export MAGICK_CONFIGURE_PATH=$ACTUAL_INSTALL_PATH/etc/ImageMagick-7" >> $PROFILE_PATH


### PR DESCRIPTION
ImageMagick binaries need to be able to find their configuration files,
and in some cases they need extra help in doing so. By setting the
`MAGICK_CONFIGURE_PATH` to the installed location of those files, we can
ensure that the binaries know where to look.