### PR TITLE
Resolve $HOME in profile.d at runtime rather than during the build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -88,11 +88,11 @@ echo "-----> Updating environment variables"
 ln -s $VENDOR_DIR/imagemagick-webp /app/vendor/imagemagick-webp
 
 PROFILE_PATH="$BUILD_DIR/.profile.d/imagemagick-webp.sh"
-ACTUAL_INSTALL_PATH="$HOME/vendor/imagemagick-webp"
+RUNTIME_INSTALL_PATH="\$HOME/vendor/imagemagick-webp"
 mkdir -p $(dirname $PROFILE_PATH)
 
-echo "export CPATH=$CPATH:$ACTUAL_INSTALL_PATH/include:$INSTALL_DIR/include" >> $PROFILE_PATH
-echo "export PATH=$ACTUAL_INSTALL_PATH/bin:\$PATH" >> $PROFILE_PATH
-echo "export PATH=$ACTUAL_INSTALL_PATH/etc/ImageMagick-7:\$PATH" >> $PROFILE_PATH
-echo "export LD_LIBRARY_PATH=$ACTUAL_INSTALL_PATH/lib:\$LD_LIBRARY_PATH" >> $PROFILE_PATH
-echo "export MAGICK_CONFIGURE_PATH=$ACTUAL_INSTALL_PATH/etc/ImageMagick-7" >> $PROFILE_PATH
+echo "export CPATH=$CPATH:$RUNTIME_INSTALL_PATH/include:$INSTALL_DIR/include" >> $PROFILE_PATH
+echo "export PATH=$RUNTIME_INSTALL_PATH/bin:\$PATH" >> $PROFILE_PATH
+echo "export PATH=$RUNTIME_INSTALL_PATH/etc/ImageMagick-7:\$PATH" >> $PROFILE_PATH
+echo "export LD_LIBRARY_PATH=$RUNTIME_INSTALL_PATH/lib:\$LD_LIBRARY_PATH" >> $PROFILE_PATH
+echo "export MAGICK_CONFIGURE_PATH=$RUNTIME_INSTALL_PATH/etc/ImageMagick-7" >> $PROFILE_PATH


### PR DESCRIPTION
Hi! I'm on the team that maintains Heroku's build system.

In the next week or so we plan on changing the value for `$HOME` at build time as part of moving where the build occurs, however this buildpack was found to not be compatible with this change, which will be fixed by this PR.

---
Previously the value for `$HOME` was resolved at build time, meaning its actual value during the build is hardcoded in the `.profile.d/` script, rather than just the variable name.

Whilst the value for `$HOME` is currently the same at both build-time and run-time (both `/app`), the build-time value (only) is due to change in the future to a path under `/tmp`.

By escaping the dollar sign, the variable `$HOME` is now resolved at runtime, making the buildpack compatible with this future change.